### PR TITLE
[CLOSES #48][CLOSES #45][CLOSES #27] Web Gradle Fixes

### DIFF
--- a/gradle/web.gradle
+++ b/gradle/web.gradle
@@ -6,6 +6,8 @@ task web(type: Exec) {
   // -Pcmd='-d': pass in argument to misk-web shell script in Docker container
   // -Ptabs='tabs/config, tabs/example': spins up parallel Docker containers with the following paths as volumes
   // -Pdockerd: boolean to run Docker container as daemon in background
+  // -Psingle: force run the command in a single non-parallelized Docker container
+  // -Pdv: docker version override to force the tab to be built with the `web.gradle` shipped default version, not the one in the tab's package.json
   // Running webpack-dev-servers for various tabs: ./gradlew web -Pcmd='-d' -Ptabs='tabs/config, tabs/example'
   // Build all tabs: ./gradlew web
   // See other misk-web options: ./gradlew web -Pcmd='-h'
@@ -24,57 +26,57 @@ task web(type: Exec) {
   def generateDockerContainerName = { task ->
     def slug = slugify(task)
     if (slug == "") {
-      return "${new Date().format("YMD-HMS")}-${projectName}-${subProjectName}"
+      return "${new Date().format("YMD-HMS")}-${projectName}-${subProjectName}-web"
     } else {
-      return "${new Date().format("YMD-HMS")}-${projectName}-${subProjectName}-${slug}"
+      return "${new Date().format("YMD-HMS")}-${projectName}-${subProjectName}-web-${slug}"
     }
   }
 
   def getPackageJsonPort = { path ->
-    def packageFile = new File("$path/package.json")
+    def packageFile = file("$path/package.json")
     def packageJson = new JsonSlurper().parseText(packageFile.text)
-    try {
-      return packageJson.miskTab.port
-    } catch (all) {
-      return null
-    }
+    return packageJson.miskTab.port
   }
 
   def getPackageVersion = { path ->
     def packageFile = new File("$path/package.json")
     def packageJson = new JsonSlurper().parseText(packageFile.text)
-    try {
-      return packageJson.miskTab.version
-    } catch (all) {
-      return null
-    }
+    return packageJson.miskTab.version
   }
 
   def generateDockerRunCommand = {
     projectPath, path, cmd, daemon = "-d", image = "squareup/misk-web" ->
-      def containerName = "${generateDockerContainerName(path)}"
-      def port = ""
-      if (path.startsWith("/tabs")) {
-        port = "-p ${getPackageJsonPort("${projectPath}/web/${path}")}:${getPackageJsonPort("${projectPath}/web/${path}")}"
+      try {
+        def containerName = "${generateDockerContainerName(path)}"
+        def port = ""
+        def rawPort = getPackageJsonPort("${projectPath}/web/${path}")
+        if (rawPort != null) {
+          port = "-p ${rawPort}:${rawPort}"
+        }
+        def versionWarningLog = ""
+        def imageVersion = getPackageVersion("${projectPath}/web/${path}")
+        if (imageVersion < dockerMiskWebVersion) {
+          def versionWarning = "\n[WARN] Upgrade miskTab.version ${imageVersion} -> ${dockerMiskWebVersion} in ${path}/package.json\nCheck for breaking changes and upgrade to latest @misk/ packages: https://github.com/square/misk/tree/master/docker/misk-web\n"
+          versionWarningLog = "; echo '$versionWarning'"
+          println versionWarning
+        }
+        if (project.hasProperty("dv")) {
+          imageVersion = dockerMiskWebVersion
+        }
+        def command = "docker run ${daemon} --rm --name ${containerName} -v ${projectPath}/web${path}:/web${path} ${port} ${image}:${imageVersion} ${cmd}"
+        def logsDir = "${projectPath}/web/logs/"
+        println "\nContainer: ${containerName} ${cmd}"
+        println "Running... \$ ${command}"
+        println "Logs       \$ docker logs -f ${containerName}"
+        println "Logs File  ${logsDir}${containerName.toString()}.log"
+        println "Shut Down  \$ docker kill ${containerName}"
+        def waitForContainer = "while ! docker ps --format '{{.Names}}' | grep -q '${containerName}'; do sleep 1; done"
+        def formattedLogs = "mkdir -p $logsDir && bash -c \'docker logs -f ${containerName} | tee \"${logsDir}${containerName.toString()}.log\" > >(sed \"s/^/[${slugify(path)}] /\") 2> >(sed \"s/^/[${slugify(path)}][err] /\" >&2) &\'"
+        return "sh -c '$command &'; $waitForContainer && $formattedLogs $versionWarningLog"
+      } catch (error) {
+        println error
+        return "sh -c 'echo \"[${path}][ERROR] This container failed because of the following error in web.gradle: ${error}\" && echo \"\" && echo \"\"'"
       }
-      def versionWarningLog = ""
-      def imageVersion = dockerMiskWebVersion
-//      def imageVersion = getPackageVersion("${projectPath}/web/${path}")
-//      if (imageVersion < dockerMiskWebVersion) {
-//        def versionWarning = "\n[WARN] Upgrade miskTab.version ${imageVersion} -> ${dockerMiskWebVersion} in ${path}/package.json\nCheck for breaking changes and upgrade to latest @misk/ packages: https://github.com/square/misk/tree/master/docker/misk-web\n"
-//        versionWarningLog = "; echo '$versionWarning'"
-//        println versionWarning
-//      }
-      def command = "docker run ${daemon} --rm --name ${containerName} -v ${projectPath}/web${path}:/web${path} ${port} ${image}:${imageVersion} ${cmd}"
-      def logsDir = "${projectPath}/web/logs/"
-      println "\nContainer: ${containerName} ${cmd}"
-      println "Running... \$ ${command}"
-      println "Logs       \$ docker logs -f ${containerName}"
-      println "Logs File  ${logsDir}${containerName.toString()}.log"
-      println "Shut Down  \$ docker kill ${containerName}"
-      def waitForContainer = "while ! docker ps --format '{{.Names}}' | grep -q '${containerName}'; do sleep 1; done"
-      def formattedLogs = "mkdir -p $logsDir && bash -c \'docker logs -f ${containerName} | tee \"${logsDir}${containerName.toString()}.log\" > >(sed \"s/^/[${slugify(path)}] /\") 2> >(sed \"s/^/[${slugify(path)}][err] /\" >&2) &\'"
-      return "sh -c '$command &'; $waitForContainer && $formattedLogs $versionWarningLog"
   }
 
   def cmd = ""
@@ -102,13 +104,14 @@ task web(type: Exec) {
     }
 
     project.tabs.split(',').each {
-      def command = generateDockerRunCommand(project.projectDir, "/$it", "/bin/misk-web ${cmd}", dockerd)
+      def command = generateDockerRunCommand(project.projectDir, "/$it", "/bin/misk-web ${cmd}",
+              dockerd)
       if (runCommand != "") {
         runCommand += " && "
       }
       runCommand += command
     }
-  } else if (single) {
+  } else if (single || cmd == "-r") {
     runCommand += generateDockerRunCommand(project.projectDir, "", "/bin/misk-web ${cmd}", dockerd)
   } else {
     // Spin up parallel images for all @misk/ packages and tabs
@@ -118,14 +121,14 @@ task web(type: Exec) {
         paths += it.toString().split('/web/').drop(1)[0]
       }
     } catch (all) {
-      println "Can't find any @misk packages in ${project.projectDir}/web/@misk"
+      println "No @misk packages found in ${project.projectDir}/web/@misk"
     }
     try {
       new File("${project.projectDir}/web/tabs").eachDir {
         paths += it.toString().split('/web/').drop(1)[0]
       }
     } catch (all) {
-      println "Can't find any tabs in ${project.projectDir}/web/tabs"
+      println "No tabs found in ${project.projectDir}/web/tabs"
     }
 
     if (paths.size() > 1) {
@@ -133,7 +136,8 @@ task web(type: Exec) {
     }
 
     paths.each {
-      def command = generateDockerRunCommand(project.projectDir, "/$it", "/bin/misk-web ${cmd}", dockerd)
+      def command = generateDockerRunCommand(project.projectDir, "/$it", "/bin/misk-web ${cmd}",
+              dockerd)
       if (runCommand != "") {
         runCommand += " && "
       }
@@ -141,7 +145,7 @@ task web(type: Exec) {
     }
   }
 
-  def sleepUntilDockerExits = "while docker ps --format '{{.Names}}' | grep -q '${projectName}-${subProjectName}'; do echo -e \"\\r\\033[1A\\033[0K[\$(date +'%Y-%m-%d %T')] waiting for [\$(docker ps --format '{{.Names}}' | grep '${projectName}-${subProjectName}' | wc -l | tr -d '\t')] ${projectName}-${subProjectName} running containers to finish...\" && sleep 5; done"
+  def sleepUntilDockerExits = "while docker ps --format '{{.Names}}' | grep -q '${projectName}-${subProjectName}-web'; do echo -e \"\\r\\033[1A\\033[0K[\$(date +'%Y-%m-%d %T')] waiting for [\$(docker ps --format '{{.Names}}' | grep '${projectName}-${subProjectName}' | wc -l | tr -d '\t')] ${projectName}-${subProjectName}-web running containers to finish...\" && sleep 5; done"
   runCommand += " && ${sleepUntilDockerExits}"
   commandLine 'sh', '-c', runCommand
 }


### PR DESCRIPTION
* [CLOSES #48]: better error handling on missing `package.json`
* [CLOSES #45]: only waits for docker containers to finish that match `{projectName}-{subProjectName}-web`
* [CLOSES #27]: Ensure port is attached even one only one tab is built