### PR TITLE
SimpleNetworkDucks Refactor

### DIFF
--- a/misk-web/web/packages/@misk/core/src/ducks/index.ts
+++ b/misk-web/web/packages/@misk/core/src/ducks/index.ts
@@ -1,3 +1,4 @@
+export * from "./simpleDucksUtilities"
 export * from "./routerDucks"
 export * from "./simpleNetworkDucks"
 

--- a/misk-web/web/packages/@misk/core/src/ducks/simpleDucksUtilities.ts
+++ b/misk-web/web/packages/@misk/core/src/ducks/simpleDucksUtilities.ts
@@ -1,0 +1,20 @@
+/**
+ * Common Utilities for use in simple*Ducks libraries
+ */
+
+/**
+ *
+ * @param json likely JSON input as a string
+ * @returns JSON or string if JSON.parse fails
+ */
+export const jsonOrString = (json: string) => {
+  try {
+    return JSON.parse(json)
+  } catch (e) {
+    return json
+  }
+}
+
+export const getPayloadTag = (payload: { [tag: string]: any }) => {
+  return payload[Object.keys(payload)[0]]
+}


### PR DESCRIPTION
* Restructure action payload to mirror the `simpleNetwork` state
* Use `state.merge()` and have tagged `simpleNetwork` calls exist in the top level of the state
* This makes for faster merges (not using `mergeDeep` anymore)
* Also allows each tagged call to have it's own metadata (success, loading, error...)