### PR TITLE
SimpleFormDucks Library

### DIFF
--- a/misk-web/web/packages/@misk/core/README.md
+++ b/misk-web/web/packages/@misk/core/README.md
@@ -32,6 +32,7 @@ $ yarn add @misk/core
 ## Ducks
 
 - `routerDucks`: router management Redux-Sagas parts (actions, dispatcher, handlers, sagas, reducers, state interface)
+- `simpleFormDucks`: a standardized set of form and input handler Redux-Sagas parts (actions, dispatcher, handlers, sagas, reducers, state interface)
 - `simpleNetworkDucks`: a standardized set of Axios based request Redux-Sagas parts (actions, dispatcher, handlers, sagas, reducers, state interface)
 
 ## Features

--- a/misk-web/web/packages/@misk/core/src/ducks/index.ts
+++ b/misk-web/web/packages/@misk/core/src/ducks/index.ts
@@ -1,5 +1,6 @@
 export * from "./simpleDucksUtilities"
 export * from "./routerDucks"
+export * from "./simpleFormDucks"
 export * from "./simpleNetworkDucks"
 
 // from @misk/common/src/actions.ts

--- a/misk-web/web/packages/@misk/core/src/ducks/simpleDucksUtilities.ts
+++ b/misk-web/web/packages/@misk/core/src/ducks/simpleDucksUtilities.ts
@@ -1,6 +1,121 @@
 /**
- * Common Utilities for use in simple*Ducks libraries
+ * simple*Ducks libraries common code
  */
+
+/**
+ * Handler Functions
+ * Reduce the legwork of parsing `onChange`, `onClick` and other events in Buttons, Inputs, Toggles...etc to call your handling function
+ *
+ * Old Way: Manually declare inline arrow funtions consuming the input events
+ * ```
+ * <InputGroup onChange={(event: any) => (props.simpleFormInput("FormInputTag", event.target.value))}
+ * <NumberInput onChange={({valueAsNumber: number, valueAsString: string}) => (props.simpleFormNumber("FormNumberTag", valueAsNumber, valueAsString))}
+ * ```
+ *
+ * New way: Use on*FnCall to wrap and implicitly pass into handling functions the input events
+ * ```
+ * <InputGroup onChange={onChangeFnCall(props.simpleFormInput, ["FormInputTag"])}
+ * <NumberInput onChange={onChangeNumberFnCall(props.simpleFormNumber, ["FormNumberTag"])}
+ * ```
+ */
+
+/**
+ *
+ * @param callFn: function to be called
+ * @param args: arguments to be passed into the callFn
+ *
+ * ```
+ * <Button onClick={onClickFnCall(props.simpleNetworkPut, ["PutTag", { ...requestBody }])}
+ * ```
+ */
+export const onClickFnCall = (callFn: any, args: any[]) => (event: any) => {
+  callFn(...args)
+}
+
+/**
+ *
+ * @param callFn: function to be called
+ * @param args: arguments to be passed into the callFn
+ *
+ * ```
+ * <InputGroup onChange={onChangeFnCall(props.simpleFormInput, ["FormInputTag"])}
+ * ```
+ */
+export const onChangeFnCall = (callFn: any, args: any[]) => (event: any) => {
+  callFn(...args, event.target.value)
+}
+
+/**
+ *
+ * @param callFn: function to be called
+ * @param args: arguments to be passed into the callFn
+ *
+ * ```
+ * <Checkbox onChange={onChangeToggleFnCall(props.simpleFormToggle, ["FormToggleTag", simpleFormState])}
+ * ```
+ */
+export const onChangeToggleFnCall = (callFn: any, args: any[]) => (
+  event: any
+) => {
+  callFn(...args, event.target.value)
+}
+
+/**
+ *
+ * @param callFn: function to be called
+ * @param args: arguments to be passed into the callFn
+ *
+ * ```
+ * <NumberInput onChange={onChangeNumberFnCall(props.simpleFormNumber, ["FormNumberTag"])}
+ * ```
+ */
+export const onChangeNumberFnCall = (callFn: any, args: any[]) => (
+  valueAsNumber: number,
+  valueAsString: string
+) => {
+  callFn(...args, valueAsNumber, valueAsString)
+}
+
+/**
+ *
+ * @param callFn: function to be called
+ * @param args: arguments to be passed into the callFn
+ *
+ * ```
+ * <TagInput onChange={onChangeTagFnCall(props.simpleFormInput, ["FormTagsTag"])}
+ * ```
+ */
+export const onChangeTagFnCall = (callFn: any, args: any[]) => (
+  values: string[]
+) => {
+  callFn(...args, values)
+}
+
+/**
+ * Utilities
+ */
+
+/**
+ * @param oldState input from the event.target.value of a button (string)
+ *                 or the oldState from Redux store (boolean)
+ */
+export const booleanToggle = (oldState: string | boolean) => {
+  if (oldState === true || oldState === "on") {
+    return false
+  } else {
+    return true
+  }
+}
+
+/**
+ * @param payload `action.payload` from Redux
+ * Assumes that the first non-order safe key accessed is the data
+ * Only use when action.payload has a single key (ie. the tag with all metadata inside)
+ * Otherwise, unpredictable key selection
+ */
+export const getPayloadTag = <T = any>(payload: { [tag: string]: T }) => {
+  return payload[Object.keys(payload)[0]]
+}
 
 /**
  *
@@ -13,8 +128,4 @@ export const jsonOrString = (json: string) => {
   } catch (e) {
     return json
   }
-}
-
-export const getPayloadTag = (payload: { [tag: string]: any }) => {
-  return payload[Object.keys(payload)[0]]
 }

--- a/misk-web/web/packages/@misk/core/src/ducks/simpleFormDucks.ts
+++ b/misk-web/web/packages/@misk/core/src/ducks/simpleFormDucks.ts
@@ -1,0 +1,302 @@
+import {
+  createAction,
+  defaultState,
+  IAction,
+  IDefaultState
+} from "@misk/common"
+import { fromJS } from "immutable"
+import { partition } from "lodash-es"
+import createCachedSelector from "re-reselect"
+import { all, AllEffect, put, takeEvery } from "redux-saga/effects"
+import { createSelector, OutputSelector, ParametricSelector } from "reselect"
+import { booleanToggle, getPayloadTag } from "."
+
+/**
+ * Actions
+ * string enum of the defined actions that is used as type enforcement for Reducer and Sagas arguments
+ */
+export enum SIMPLEFORM {
+  INPUT = "SIMPLEFORM_INPUT",
+  FAILURE = "SIMPLEFORM_FAILURE",
+  NUMBER = "SIMPLEFORM_NUMBER",
+  SUCCESS = "SIMPLEFORM_SUCCESS",
+  TOGGLE = "SIMPLEFORM_TOGGLE"
+}
+
+/**
+ * Dispatch Object
+ * Object of functions that dispatch Actions with standard defaults and any required passed in input
+ * dispatch Object is used within containers to initiate any saga provided functionality
+ */
+export interface ISimpleFormPayload extends IDefaultState {
+  oldToggle?: string | boolean
+  tag: string
+  valueAsString?: string
+  valueAsNumber?: number
+}
+
+export interface IDispatchSimpleForm {
+  simpleFormFailure: (
+    tag: string,
+    error: any
+  ) => IAction<SIMPLEFORM.FAILURE, ISimpleFormState>
+  simpleFormInput: (
+    tag: string,
+    data: any
+  ) => IAction<SIMPLEFORM.INPUT, ISimpleFormState>
+  simpleFormNumber: (
+    tag: string,
+    valueAsNumber: number,
+    valueAsString: string
+  ) => IAction<SIMPLEFORM.NUMBER, ISimpleFormState>
+  simpleFormSuccess: (
+    tag: string,
+    data: any
+  ) => IAction<SIMPLEFORM.SUCCESS, ISimpleFormState>
+  simpleFormToggle: (
+    tag: string,
+    oldState: any
+  ) => IAction<SIMPLEFORM.TOGGLE, ISimpleFormState>
+}
+
+export const dispatchSimpleForm: IDispatchSimpleForm = {
+  simpleFormFailure: (tag: string, error: any) =>
+    createAction<SIMPLEFORM.FAILURE, ISimpleFormState>(SIMPLEFORM.FAILURE, {
+      [tag]: {
+        ...error,
+        loading: false,
+        success: false,
+        tag
+      }
+    }),
+  simpleFormInput: (tag: string, data: any) =>
+    createAction<SIMPLEFORM.INPUT, ISimpleFormState>(SIMPLEFORM.INPUT, {
+      [tag]: {
+        data,
+        error: null,
+        loading: true,
+        success: false,
+        tag
+      }
+    }),
+  simpleFormNumber: (
+    tag: string,
+    valueAsNumber: number,
+    valueAsString: string
+  ) =>
+    createAction<SIMPLEFORM.NUMBER, ISimpleFormState>(SIMPLEFORM.NUMBER, {
+      [tag]: {
+        data: valueAsString,
+        error: null,
+        loading: true,
+        success: false,
+        tag
+      }
+    }),
+  simpleFormSuccess: (tag: string, data: any) =>
+    createAction<SIMPLEFORM.SUCCESS, ISimpleFormState>(SIMPLEFORM.SUCCESS, {
+      [tag]: {
+        ...data,
+        error: null,
+        loading: false,
+        success: true,
+        tag
+      }
+    }),
+  simpleFormToggle: (tag: string, oldState: any) =>
+    createAction<SIMPLEFORM.TOGGLE, ISimpleFormState>(SIMPLEFORM.TOGGLE, {
+      [tag]: {
+        oldToggle: valueSimpleForm(oldState, tag),
+        error: null,
+        loading: true,
+        success: false,
+        tag
+      }
+    })
+}
+
+/**
+ * Sagas are generating functions that consume actions and
+ * pass either latest (takeLatest) or every (takeEvery) action
+ * to a handling generating function.
+ *
+ * Handling function is where obtaining web resources is done
+ * Web requests are done within try/catch so that
+ *  if request fails: a failure action is dispatched
+ *  if request succeeds: a success action with the data is dispatched
+ * Further processing of the data should be minimized within the handling
+ *  function to prevent unhelpful errors. Ie. a failed request error is
+ *  returned but it actually was just a parsing error within the try/catch.
+ */
+
+function* handleBasicRequest(action: IAction<SIMPLEFORM, ISimpleFormState>) {
+  try {
+    const { data, tag } = getPayloadTag(action.payload)
+    yield put(
+      dispatchSimpleForm.simpleFormSuccess(tag, {
+        ...getPayloadTag(action.payload),
+        data
+      })
+    )
+  } catch (e) {
+    const { tag } = getPayloadTag(action.payload)
+    yield put(
+      dispatchSimpleForm.simpleFormFailure(tag, {
+        ...getPayloadTag(action.payload),
+        ...e
+      })
+    )
+  }
+}
+
+function* handleToggle(action: IAction<SIMPLEFORM, ISimpleFormState>) {
+  try {
+    const { oldToggle, tag } = getPayloadTag<ISimpleFormPayload>(action.payload)
+    yield put(
+      dispatchSimpleForm.simpleFormSuccess(tag, {
+        ...getPayloadTag<ISimpleFormPayload>(action.payload),
+        data: booleanToggle(oldToggle)
+      })
+    )
+  } catch (e) {
+    const { tag } = getPayloadTag<ISimpleFormPayload>(action.payload)
+    yield put(
+      dispatchSimpleForm.simpleFormFailure(tag, {
+        ...getPayloadTag<ISimpleFormPayload>(action.payload),
+        ...e
+      })
+    )
+  }
+}
+
+export function* watchSimpleFormSagas(): IterableIterator<AllEffect> {
+  yield all([
+    takeEvery(SIMPLEFORM.INPUT, handleBasicRequest),
+    takeEvery(SIMPLEFORM.NUMBER, handleBasicRequest),
+    takeEvery(SIMPLEFORM.TOGGLE, handleToggle)
+  ])
+}
+
+/**
+ * Initial State
+ * Reducer merges all changes from dispatched action objects on to this initial state
+ */
+const initialState = fromJS({
+  ...defaultState.toJS()
+})
+
+/**
+ * Duck Reducer
+ * Merges dispatched action objects on to the existing (or initial) state to generate new state
+ */
+export function SimpleFormReducer(
+  state = initialState,
+  action: IAction<SIMPLEFORM, {}>
+) {
+  switch (action.type) {
+    case SIMPLEFORM.FAILURE:
+    case SIMPLEFORM.INPUT:
+    case SIMPLEFORM.NUMBER:
+    case SIMPLEFORM.SUCCESS:
+    case SIMPLEFORM.TOGGLE:
+      return state.merge(action.payload)
+    default:
+      return state
+  }
+}
+
+/**
+ * State Interface
+ * Provides a complete Typescript interface for the object on state that this duck manages
+ * Consumed by the root reducer in ./ducks index to update global state
+ * Duck state is attached at the root level of global state
+ */
+
+export interface ISimpleFormState extends IDefaultState {
+  [tag: string]: any | ISimpleFormPayload
+}
+
+/**
+ * Selector
+ * A memoized, efficient way to compute and return the latest domain of the state
+ */
+export const simpleFormState = <T extends { simpleForm: ISimpleFormState }>(
+  state: T
+) => state.simpleForm
+
+export const simpleFormSelector: OutputSelector<
+  {},
+  any,
+  (res: ISimpleFormState) => any
+> = createSelector(
+  simpleFormState,
+  state => state.toJS()
+)
+
+export const getSimpleForm: ParametricSelector<
+  {},
+  string,
+  ISimpleFormPayload
+> = createCachedSelector(
+  simpleFormState,
+  (simpleForm: ISimpleFormState, tag: string) =>
+    simpleForm[tag] ? simpleForm[tag] : defaultState,
+  (state: ISimpleFormState, tagResponse: ISimpleFormPayload) => tagResponse
+)((state, tag) => tag)
+
+export const querySimpleForm: ParametricSelector<
+  {},
+  string,
+  ISimpleFormPayload
+> = createCachedSelector(
+  simpleFormState,
+  (simpleForm: ISimpleFormState, tag: string) => {
+    return partition(Object.keys(simpleForm), k => k.startsWith(tag))[0]
+      .length > 0
+      ? partition(Object.keys(simpleForm), k => k.startsWith(tag))[0].map(
+          k => simpleForm[k]
+        )
+      : defaultState
+  },
+  (state: ISimpleFormState, tagResponse: ISimpleFormPayload) => tagResponse
+)((state, tag) => tag)
+
+export const querySimpleFormData: ParametricSelector<
+  {},
+  string,
+  ISimpleFormPayload
+> = createCachedSelector(
+  simpleFormState,
+  (simpleForm: ISimpleFormState, tag: string) => {
+    return partition(Object.keys(simpleForm), k => k.startsWith(tag))[0]
+      .length > 0
+      ? partition(Object.keys(simpleForm), k => k.startsWith(tag))[0].map(
+          k => ({ [k]: simpleForm[k].data })
+        )
+      : defaultState
+  },
+  (state: ISimpleFormState, tagResponse: ISimpleFormPayload) => tagResponse
+)((state, tag) => tag)
+
+export const valueSimpleForm = (simpleForm: ISimpleFormState, tag: string) => {
+  try {
+    const { data } = getSimpleForm(simpleForm, tag)
+    return data
+  } catch (e) {}
+}
+
+export const valueSimpleFormTags = (
+  simpleForm: ISimpleFormState,
+  tag: string
+) => {
+  try {
+    const data = valueSimpleForm(simpleForm, tag)
+    if (data instanceof Array) {
+      return data
+    } else {
+      return [] as string[]
+    }
+  } catch (e) {
+    return [] as string[]
+  }
+}


### PR DESCRIPTION
* Redux-Sagas parts and input handlers for use with building forms
* Generic `onClickFnCall` and other utilities to minimize manual event handling from predictable component inputs (ie. `<InputGroup` always returns data in `event.target.value` but `<TagInput` returns an array of the tags in `values`)