### PR TITLE
Core: CodePreContainer

### DIFF
--- a/packages/@misk/core/README.md
+++ b/packages/@misk/core/README.md
@@ -23,6 +23,7 @@ $ yarn add @misk/core
 
 ## Containers
 
+- `CodePreContainer`: Word wrap enabled BlueprintJS `<Pre>` block for displaying formatted content (ie. JSON, logs...)
 - `DesktopWideOnlyContainer`: Only shows container when window width >1200px
 - `FlexContainer`: Container using CSS FlexBox to have enclosed items flow responsively to screen width
 - `MobileNeverContainer`: Never show container when window width <768px

--- a/packages/@misk/core/src/containers/CodePreContainer.tsx
+++ b/packages/@misk/core/src/containers/CodePreContainer.tsx
@@ -1,0 +1,22 @@
+import { Pre } from "@blueprintjs/core"
+import { FunctionComponent, HTMLProps } from "react"
+import styled, { StyledComponent } from "styled-components"
+
+/**
+ * <CodePreContainer>
+ *    <span>Stuff</span>
+ * </CodePreContainer>
+ */
+export const CodePreContainer: StyledComponent<
+  FunctionComponent<HTMLProps<HTMLElement>>,
+  any,
+  {},
+  never
+> = styled(Pre)`
+  font-family: Fira Code, Menlo;
+  white-space: pre-wrap; /* Since CSS 2.1 */
+  white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+  white-space: -pre-wrap; /* Opera 4-6 */
+  white-space: -o-pre-wrap; /* Opera 7 */
+  word-wrap: break-word; /* Internet Explorer 5.5+ */
+`

--- a/packages/@misk/core/src/containers/index.ts
+++ b/packages/@misk/core/src/containers/index.ts
@@ -1,3 +1,4 @@
+export * from "./CodePreContainer"
 export * from "./DesktopWideOnlyContainer"
 export * from "./FlexContainer"
 export * from "./MobileNeverContainer"


### PR DESCRIPTION
`CodePreContainer`: Word wrap enabled BlueprintJS `<Pre>` block for displaying formatted content (ie. JSON, logs...)