### PR TITLE
[SimpleRedux] Add simpleRootRawSelector

### DIFF
--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -12,7 +12,7 @@
   {
     "definitionName": "lockStepVersion",
     "policyName": "MiskWeb",
-    "version": "0.1.5-19",
+    "version": "0.1.5-20",
     "nextBump": "prerelease"
   }
   // {

--- a/examples/tabs/palette-exemplar/package.json
+++ b/examples/tabs/palette-exemplar/package.json
@@ -22,9 +22,9 @@
     "zip": "tar --exclude='.gitignore' --exclude='.old_build_files' --exclude='package.json' --exclude='package-lock.json' --exclude='prettier.config.js' --exclude='tsconfig.json' --exclude='tslint.json' --exclude='webpack.config.js' --exclude='yarn.lock' --exclude='demo' --exclude='lib' --exclude='.DS_Store' --exclude='*.log' --exclude='node_modules' --exclude='palette-exemplar.tgz' -czvf palette-exemplar.tgz ./"
   },
   "dependencies": {
-    "@misk/common": "0.1.5-19",
-    "@misk/core": "0.1.5-19",
-    "@misk/simpleredux": "0.1.5-19",
+    "@misk/common": "0.1.5-20",
+    "@misk/core": "0.1.5-20",
+    "@misk/simpleredux": "0.1.5-20",
     "@blueprintjs/core": "^3.9.0",
     "@blueprintjs/datetime": "^3.4.0",
     "@blueprintjs/icons": "^3.3.0",
@@ -55,8 +55,8 @@
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@misk/dev": "0.1.5-19",
-    "@misk/tslint": "0.1.5-19",
+    "@misk/dev": "0.1.5-20",
+    "@misk/tslint": "0.1.5-20",
     "@types/history": "^4.7.2",
     "@types/node": "^10.12.18",
     "@types/react": "^16.7.18",

--- a/examples/tabs/palette/package.json
+++ b/examples/tabs/palette/package.json
@@ -22,9 +22,9 @@
     "zip": "tar --exclude='.gitignore' --exclude='.old_build_files' --exclude='package.json' --exclude='package-lock.json' --exclude='prettier.config.js' --exclude='tsconfig.json' --exclude='tslint.json' --exclude='webpack.config.js' --exclude='yarn.lock' --exclude='demo' --exclude='lib' --exclude='.DS_Store' --exclude='*.log' --exclude='node_modules' --exclude='palette.tgz' -czvf palette.tgz ./"
   },
   "dependencies": {
-    "@misk/common": "0.1.5-19",
-    "@misk/core": "0.1.5-19",
-    "@misk/simpleredux": "0.1.5-19",
+    "@misk/common": "0.1.5-20",
+    "@misk/core": "0.1.5-20",
+    "@misk/simpleredux": "0.1.5-20",
     "@blueprintjs/core": "^3.9.0",
     "@blueprintjs/datetime": "^3.4.0",
     "@blueprintjs/icons": "^3.3.0",
@@ -55,8 +55,8 @@
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@misk/dev": "0.1.5-19",
-    "@misk/tslint": "0.1.5-19",
+    "@misk/dev": "0.1.5-20",
+    "@misk/tslint": "0.1.5-20",
     "@types/history": "^4.7.2",
     "@types/node": "^10.12.18",
     "@types/react": "^16.7.18",

--- a/packages/@misk/cli/package.json
+++ b/packages/@misk/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/cli",
-  "version": "0.1.5-19",
+  "version": "0.1.5-20",
   "license": "SEE LICENSE IN https://github.com/square/misk-web",
   "description": "Misk-Web CLI Build Tool",
   "author": "Square/Misk Authors (https://github.com/square/misk-web/graphs/contributors)",
@@ -28,8 +28,8 @@
     "yargs": "^12.0.4"
   },
   "devDependencies": {
-    "@misk/dev": "0.1.5-19",
-    "@misk/tslint": "0.1.5-19",
+    "@misk/dev": "0.1.5-20",
+    "@misk/tslint": "0.1.5-20",
     "@types/fs-extra": "^5.0.4",
     "@types/klaw": "^3.0.0",
     "@types/lodash": "^4.14.121",

--- a/packages/@misk/cli/src/utils/changelog.ts
+++ b/packages/@misk/cli/src/utils/changelog.ts
@@ -1,6 +1,7 @@
 export enum MiskVersion {
-  "latest" = "0.1.5-19",
-  "alpha" = "0.1.5-19",
+  "latest" = "0.1.5-20",
+  "alpha" = "0.1.5-20",
+  "v015_20" = "0.1.5-20",
   "v015_19" = "0.1.5-19",
   "v015_18" = "0.1.5-18",
   "v015_16" = "0.1.5-16",
@@ -112,6 +113,16 @@ export const getPackageVersion = (
 }
 
 export const MiskTabVersions: IMiskTabVersions = {
+  [MiskVersion.v015_20]: {
+    [MiskPkg.cli]: `${[MiskVersion.v015_20]}`,
+    [MiskPkg.common]: `${[MiskVersion.v015_20]}`,
+    [MiskPkg.core]: `${[MiskVersion.v015_20]}`,
+    [MiskPkg.dev]: `${[MiskVersion.v015_20]}`,
+    [MiskPkg.simpleredux]: `${[MiskVersion.v015_20]}`,
+    [MiskPkg.tslint]: `${[MiskVersion.v015_20]}`,
+    date: "2019-04-05",
+    notes: "SimpleRedux: Add simpleRootRawSelector."
+  },
   [MiskVersion.v015_19]: {
     [MiskPkg.cli]: `${[MiskVersion.v015_19]}`,
     [MiskPkg.common]: `${[MiskVersion.v015_19]}`,

--- a/packages/@misk/common/package.json
+++ b/packages/@misk/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/common",
-  "version": "0.1.5-19",
+  "version": "0.1.5-20",
   "license": "SEE LICENSE IN https://github.com/square/misk-web",
   "description": "Misk-Web Common Libraries, Styles",
   "author": "Square/Misk Authors (https://github.com/square/misk-web/graphs/contributors)",
@@ -65,8 +65,8 @@
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@misk/dev": "0.1.5-19",
-    "@misk/tslint": "0.1.5-19",
+    "@misk/dev": "0.1.5-20",
+    "@misk/tslint": "0.1.5-20",
     "@types/history": "^4.7.2",
     "@types/lodash": "^4.14.121",
     "@types/node": "^10.12.18",

--- a/packages/@misk/core/package.json
+++ b/packages/@misk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/core",
-  "version": "0.1.5-19",
+  "version": "0.1.5-20",
   "license": "SEE LICENSE IN https://github.com/square/misk-web",
   "description": "Misk-Web Core",
   "author": "Square/Misk Authors (https://github.com/square/misk-web/graphs/contributors)",
@@ -33,8 +33,8 @@
     "updateDevCache": "cd ..; ./updateLocalCache.sh"
   },
   "dependencies": {
-    "@misk/common": "0.1.5-19",
-    "@misk/simpleredux": "0.1.5-19",
+    "@misk/common": "0.1.5-20",
+    "@misk/simpleredux": "0.1.5-20",
     "@blueprintjs/core": "^3.9.0",
     "@blueprintjs/datetime": "^3.4.0",
     "@blueprintjs/icons": "^3.3.0",
@@ -66,8 +66,8 @@
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@misk/dev": "0.1.5-19",
-    "@misk/tslint": "0.1.5-19",
+    "@misk/dev": "0.1.5-20",
+    "@misk/tslint": "0.1.5-20",
     "@types/history": "^4.7.2",
     "@types/lodash": "^4.14.121",
     "@types/node": "^10.12.18",

--- a/packages/@misk/dev/package.json
+++ b/packages/@misk/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/dev",
-  "version": "0.1.5-19",
+  "version": "0.1.5-20",
   "license": "SEE LICENSE IN https://github.com/square/misk-web",
   "description": "Misk-Web Build and Dev Tools",
   "author": "Square/Misk Authors (https://github.com/square/misk-web/graphs/contributors)",

--- a/packages/@misk/simpleredux/package.json
+++ b/packages/@misk/simpleredux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/simpleredux",
-  "version": "0.1.5-19",
+  "version": "0.1.5-20",
   "license": "SEE LICENSE IN https://github.com/square/misk-web",
   "description": "Misk-Web SimpleRedux",
   "author": "Square/Misk Authors (https://github.com/square/misk-web/graphs/contributors)",
@@ -33,7 +33,7 @@
     "updateDevCache": "cd ..; ./updateLocalCache.sh"
   },
   "dependencies": {
-    "@misk/common": "0.1.5-19",
+    "@misk/common": "0.1.5-20",
     "@blueprintjs/core": "^3.9.0",
     "@blueprintjs/datetime": "^3.4.0",
     "@blueprintjs/icons": "^3.3.0",
@@ -65,8 +65,8 @@
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@misk/dev": "0.1.5-19",
-    "@misk/tslint": "0.1.5-19",
+    "@misk/dev": "0.1.5-20",
+    "@misk/tslint": "0.1.5-20",
     "@types/history": "^4.7.2",
     "@types/lodash": "^4.14.121",
     "@types/node": "^10.12.18",

--- a/packages/@misk/simpleredux/src/utilities.ts
+++ b/packages/@misk/simpleredux/src/utilities.ts
@@ -108,6 +108,22 @@ const selectSubState: <
   return state[domain]
 }
 
+const rawSubStateSelector: <
+  IState extends { [key: string]: ISubState & any },
+  ISubState
+>(
+  domain: string
+) => OutputSelector<IState, any, (res: ISubState) => any> = <
+  IState extends { [key: string]: ISubState },
+  ISubState
+>(
+  domain: string
+) =>
+  createSelector(
+    selectSubState<IState, ISubState>(domain),
+    state => state
+  )
+
 const immutableSubStateSelector: <
   IState extends { [key: string]: ISubState & any },
   ISubState extends { toJS: () => IRootState }
@@ -123,6 +139,21 @@ const immutableSubStateSelector: <
     selectSubState<IState, ISubState>(domain),
     state => state.toJS()
   )
+
+/**
+ * simpleRootRawSelector is a Redux selector of a subState based on a domain string
+ * @param domain
+ * @param state
+ *
+ * Returns the raw stored object from Redux (in contrast to simpleRootSelector)
+ */
+export const simpleRootRawSelector = <
+  IState extends { [key: string]: ISubState & any },
+  ISubState
+>(
+  domain: string,
+  state: IState
+) => rawSubStateSelector<IState, ISubState>(domain)(state)
 
 /**
  * simpleRootSelector is a Redux selector of a subState based on a domain string

--- a/packages/@misk/tslint/package.json
+++ b/packages/@misk/tslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@misk/tslint",
-  "version": "0.1.5-19",
+  "version": "0.1.5-20",
   "license": "SEE LICENSE IN https://github.com/square/misk-web",
   "description": "Misk-Web TsLint",
   "author": "Square/Misk Authors (https://github.com/square/misk-web/graphs/contributors)",


### PR DESCRIPTION
`simpleRootSelector` automatically dumps to basic JS the stored ImmutableJS object from Redux. Sometimes we want it raw (ie. misk/web-actions)