### PR TITLE
Fix @misk/test to allow React snapshots

### DIFF
--- a/packages/@misk/test/src/index.ts
+++ b/packages/@misk/test/src/index.ts
@@ -1,5 +1,5 @@
 export const testPackageScript = {
-  test: "jest --passWithNoTests"
+  test: "jest --passWithNoTests --env=jsdom"
 }
 
 export const testPackageJson = {


### PR DESCRIPTION
* Fixes error of `ReferenceError: document is not defined` where jest could not find an HTML document where the rendered component could be found
* Runs tests inside of a JS DOM environment where HTML can be rendered and tested