### PR TITLE
Override default Renovate ignorePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,11 @@
 {
   "extends": ["config:base"],
   "automerge": true,
-  "includePaths": [
-    "common/**",
-    "examples/services/**",
-    "examples/tabs/**",
-    "packages/@misk/**"
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/tests/**"
   ]
 }


### PR DESCRIPTION
* Renovate has `**/examples/**` and `**/test/**` as hidden default ignorePaths that were causing examples/** and @misk/test directories to get missed