### PR TITLE
Add second Node CI task to pass on looser update (vs install)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  node:
+  nodeInstall:
     working_directory: ~/misk-web
     docker:
       - image: circleci/node:10.15
@@ -15,6 +15,24 @@ jobs:
       - run:
           name: Installing...
           command: node common/scripts/install-run-rush.js install
+      - run:
+          name: Building...
+          command: node common/scripts/install-run-rush.js rebuild --verbose
+  nodeUpdate:
+    working_directory: ~/misk-web
+    docker:
+      - image: circleci/node:10.15
+    steps:
+      - checkout
+      - run:
+          name: Misk-Web Prebuild...
+          command: sudo npm install -g @misk/cli && miskweb prebuild -e
+      - run:
+          name: Checking for inconsistent dependency versions
+          command: node common/scripts/install-run-rush.js check
+      - run:
+          name: Updating...
+          command: node common/scripts/install-run-rush.js update
       - run:
           name: Building...
           command: node common/scripts/install-run-rush.js rebuild --verbose


### PR DESCRIPTION
* Human made PRs with changed NPM versions should run `rush update` to update the shrinkwrap.yaml
* Renovate and bot made PRs won't have run `rush update` but should still pass CI
* In Github the new `nodeUpdate` can be a required check, while `nodeInstall` can be left optional but be a sign to humans that their PRs should be fixed before merging